### PR TITLE
Fix: Ensure reliable redirection to dashboard after login

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react"
 
-import { useState } from "react"
+import { useState, useEffect } from "react" // Added useEffect
 import { useRouter } from "next/navigation"
 import Link from "next/link"
 import { Eye, EyeOff, Mail, Lock, LogIn } from "lucide-react"
@@ -13,19 +13,27 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { supabase } from "@/lib/supabase"
 import { useToast } from "@/hooks/use-toast"
+import { useAuth } from "@/components/auth-provider" // Added useAuth
 
 export default function LoginPage() {
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
   const [showPassword, setShowPassword] = useState(false)
-  const [loading, setLoading] = useState(false)
+  const [formLoading, setFormLoading] = useState(false) // Renamed to avoid conflict
   const [error, setError] = useState("")
   const router = useRouter()
   const { toast } = useToast()
+  const { user, loading: authLoading } = useAuth(); // Called useAuth
+
+  useEffect(() => {
+    if (!authLoading && user && router) {
+      router.push("/dashboard");
+    }
+  }, [user, authLoading, router]);
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault()
-    setLoading(true)
+    setFormLoading(true) // Use renamed state setter
     setError("")
 
     try {
@@ -60,7 +68,7 @@ export default function LoginPage() {
         variant: "destructive",
       })
     } finally {
-      setLoading(false)
+      setFormLoading(false) // Use renamed state setter
     }
   }
 
@@ -157,9 +165,9 @@ export default function LoginPage() {
             <Button
               type="submit"
               className="w-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 text-white"
-              disabled={loading}
+              disabled={formLoading} // Use renamed state
             >
-              {loading ? (
+              {formLoading ? ( // Use renamed state
                 <div className="flex items-center gap-2">
                   <div className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
                   Signing in...

--- a/components/auth-provider.tsx
+++ b/components/auth-provider.tsx
@@ -93,7 +93,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     })
 
     return () => subscription?.unsubscribe() // Add null check for subscription
-  }, [configured, supabaseClient, loading]) // Add supabaseClient and loading to dependency array
+  }, [supabaseClient]) // Add supabaseClient and loading to dependency array
 
   const signOut = async () => {
     if (!configured || !supabaseClient) return


### PR DESCRIPTION
Previously, you might not have been redirected to the dashboard after a successful login, or you might have been redirected back to the login page. This was likely due to a race condition between the login process, the update of the authentication state in AuthProvider, and the rendering of ProtectedRoute.

This commit addresses the issue by:

1.  Refining `AuthProvider` (`components/auth-provider.tsx`):
    -   The main `useEffect` hook that handles initial session loading and subscribes to `onAuthStateChange` now has its dependencies correctly set to `[supabaseClient]`. This prevents the hook from re-running unnecessarily due to `loading` state changes, ensuring more stable auth state management.

2.  Adding Reactive Redirection to Login Page (`app/login/page.tsx`):
    -   A `useEffect` hook has been added to the login page.
    -   This hook uses `useAuth()` to monitor the `user` and `loading` (authLoading) states.
    -   If `authLoading` is false and a `user` is present (i.e., authenticated), the page automatically redirects to `/dashboard`.
    -   This ensures that even if the optimistic redirect in `handleLogin` doesn't result in a stable dashboard view immediately (due to the aforementioned race condition), this reactive mechanism will ensure you are sent to the dashboard once the authentication state is confirmed.
    -   A local `loading` state in the login form was renamed to `formLoading` to prevent conflicts with the `authLoading` state from `useAuth`.

These changes ensure a more robust and reliable redirection to the dashboard post-login, improving your experience.